### PR TITLE
Fixed Leaderboard Not Updating Issue (I am currently the only participant ranked)

### DIFF
--- a/python/vcc_skeleton.py
+++ b/python/vcc_skeleton.py
@@ -17,7 +17,7 @@ from Question6 import question06
 class Test(unittest.TestCase):
 
     def test_runq1_main(self):
-        travis_uuid = os.environ.get('travistestidentifier', '')
+        travis_uuid = os.environ.get('travis_uuid', '')
         print(travis_uuid)
         if travis_uuid != '' or None:
             url = "https://cscc-gl.herokuapp.com/tests/run/1/" + travis_uuid
@@ -67,11 +67,11 @@ class Test(unittest.TestCase):
         if travis_uuid != '' or None:
             jsonresponse = json.dumps(response)
             headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-            requests.post('https://cscc-gl.herokuapp.com/answer/contestant/' + travis_uuid + '/1',
+            requests.post('https://cscc-us.herokuapp.com/answer/contestant/' + travis_uuid + '/1',
                           data=jsonresponse, headers=headers)
 
     def test_runq2_main(self):
-        travis_uuid = os.environ.get('travistestidentifier', '')
+        travis_uuid = os.environ.get('travis_uuid', '')
         if travis_uuid != '' or None:
             url = "https://cscc-gl.herokuapp.com/tests/run/2/" + travis_uuid
         else:
@@ -119,11 +119,11 @@ class Test(unittest.TestCase):
         if travis_uuid != '' or None:
             jsonresponse = json.dumps(response)
             headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-            requests.post('https://cscc-gl.herokuapp.com/answer/contestant/' + travis_uuid + '/2',
+            requests.post('https://cscc-us.herokuapp.com/answer/contestant/' + travis_uuid + '/2',
                           data=jsonresponse, headers=headers)
 
     def test_runq3_main(self):
-        travis_uuid = os.environ.get('travistestidentifier', '')
+        travis_uuid = os.environ.get('travis_uuid', '')
         if travis_uuid != '' or None:
             url = "https://cscc-gl.herokuapp.com/tests/run/3/" + travis_uuid
         else:
@@ -171,11 +171,11 @@ class Test(unittest.TestCase):
         if travis_uuid != '' or None:
             jsonresponse = json.dumps(response)
             headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-            requests.post('https://cscc-gl.herokuapp.com/answer/contestant/' + travis_uuid + '/3',
+            requests.post('https://cscc-us.herokuapp.com/answer/contestant/' + travis_uuid + '/3',
                           data=jsonresponse, headers=headers)
 
     def test_runq4_main(self):
-        travis_uuid = os.environ.get('travistestidentifier', '')
+        travis_uuid = os.environ.get('travis_uuid', '')
         if travis_uuid != '' or None:
             url = "https://cscc-gl.herokuapp.com/tests/run/4/" + travis_uuid
         else:
@@ -224,11 +224,11 @@ class Test(unittest.TestCase):
             jsonresponse = json.dumps(response)
             print(jsonresponse)
             headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-            requests.post('https://cscc-gl.herokuapp.com/answer/contestant/' + travis_uuid + '/4',
+            requests.post('https://cscc-us.herokuapp.com/answer/contestant/' + travis_uuid + '/4',
                           data=jsonresponse, headers=headers)
 
     def test_runq5_main(self):
-        travis_uuid = os.environ.get('travistestidentifier', '')
+        travis_uuid = os.environ.get('travis_uuid', '')
         if travis_uuid != '' or None:
             url = "https://cscc-gl.herokuapp.com/tests/run/5/" + travis_uuid
         else:
@@ -277,11 +277,11 @@ class Test(unittest.TestCase):
         if travis_uuid != '' or None:
             jsonresponse = json.dumps(response)
             headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-            requests.post('https://cscc-gl.herokuapp.com/answer/contestant/' + travis_uuid + '/5',
+            requests.post('https://cscc-us.herokuapp.com/answer/contestant/' + travis_uuid + '/5',
                           data=jsonresponse, headers=headers)
 
     def test_runq6_main(self):
-        travis_uuid = os.environ.get('travistestidentifier', '')
+        travis_uuid = os.environ.get('travis_uuid', '')
         if travis_uuid != '' or None:
             url = "https://cscc-gl.herokuapp.com/tests/run/6/" + travis_uuid
         else:
@@ -329,7 +329,7 @@ class Test(unittest.TestCase):
         if travis_uuid != '' or None:
             jsonresponse = json.dumps(response)
             headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-            requests.post('https://cscc-gl.herokuapp.com/answer/contestant/' + travis_uuid + '/6',
+            requests.post('https://cscc-us.herokuapp.com/answer/contestant/' + travis_uuid + '/6',
                           data=jsonresponse, headers=headers)
 
 


### PR DESCRIPTION
Hi Credit Suisse!

I am not a developer at Credit Suisse (I am just a college student participating in the competition), but I spent this morning trying to debug the Credit Suisse Coding Challenge site to figure out why the Individual/University leaderboard was not updating.

I was able to successfully debug and bypass the issue, and I am currently the only ranked person on the global leaderboard (Screenshot below).  

[Screenshot of the leaderboard on Oct 5th](http://www.christopherlambert.me/ss.png)

## Debugging Steps

So originally I figured it was a build issue with Travis CI, so I looked at ```.travis.yml``` and saw that it was just running vcc_skeleton.py.  I wasn't able to look at the logs at all to see if there was a build failure, so I set up an endpoint on one of my digital ocean servers and added a network call to my IP in vcc_skeleton.py. 

This logic would send a GET request whenever the build started, and I could use the Flask logs to see when the endpoint was hit as it indicated that the build had started.

I quickly found out that the build was starting, so it must be an issue with one of the endpoints called in vcc_skeleton.py.

To debug the Credit Suisse score submission API endpoint, I would need the code contained in the "travistestidentifier" environment variable that's referenced in vcc_skeleton.py.

To get the "travistestidentifier" code, I added the following to vcc_skeleton.py and looked at my Flask logs to view the parameters passed in the URL:

```python
code = os.environ.get('travistestidentifier', '')
requests.get(myIPAddress + "?code={}".format(code))
```

I found out that "travistestidentifier" was simply my Github username, so I hardcoded this in and started testing things locally.  I found out that the cscc-gl.herokuapp.com was returning a ```406``` status code with an empty response body.  

This was not very helpful, so I started playing around with the request that's sent to this endpoint.  After a ton of null 500 errors, I eventually stumbled upon a helpful 500 error by changing the locale to from ```gl``` to ```us``` and removing ```'Accept': 'text/plain'``` from the request header.

The 500 error said the following: ```Invalid UUID string: theriley106```

That meant that the code that's sent was not a valid UUID (Since it's a Github username), which means that the environment variable assigned in the Travis CI was likely incorrect.  

I looked at other files in the repo and saw a reference to "travis_uuid", which seemed to be a valid UUID (tested using the previous method from before).  I changed the code to reference the "travis_uuid" environment variable instead of the "travistestidentifier" environment variable and was successfully able to submit my score after pushing my changes to my local repo :)

If you guys have any questions please let me know!